### PR TITLE
Add election picker to home view

### DIFF
--- a/app/src/androidTest/java/com/votinginfoproject/VotingInformationProject/ModelTests/ElectionTests.java
+++ b/app/src/androidTest/java/com/votinginfoproject/VotingInformationProject/ModelTests/ElectionTests.java
@@ -1,0 +1,30 @@
+package com.votinginfoproject.VotingInformationProject.ModelTests;
+
+import com.votinginfoproject.VotingInformationProject.models.Election;
+
+import junit.framework.TestCase;
+
+/**
+ * Created by andrew on 8/1/14.
+ */
+public class ElectionTests extends TestCase {
+
+    public void testEmptyContstructorCreatesNullProperties() {
+        Election election = new Election();
+        assertNull(election.id);
+        assertNull(election.name);
+        assertNull(election.electionDay);
+    }
+
+    public void testGetIdReturnsEmptyStringForNullValue() {
+        Election election = new Election();
+        election.id = null;
+        assertEquals(election.getId(), "");
+    }
+
+    public void testGetNameReturnsEmptyStringForNullValue() {
+        Election election = new Election();
+        election.name = null;
+        assertEquals(election.getName(), "");
+    }
+}

--- a/app/src/androidTest/java/com/votinginfoproject/VotingInformationProject/ModelTests/VoterInfoTests.java
+++ b/app/src/androidTest/java/com/votinginfoproject/VotingInformationProject/ModelTests/VoterInfoTests.java
@@ -1,0 +1,16 @@
+package com.votinginfoproject.VotingInformationProject.ModelTests;
+
+import com.votinginfoproject.VotingInformationProject.models.VoterInfo;
+
+import junit.framework.TestCase;
+
+/**
+ * Created by andrew on 8/1/14.
+ */
+public class VoterInfoTests extends TestCase {
+
+    public void testOtherElectionsNotNull() {
+        VoterInfo voterInfo = new VoterInfo();
+        assertNotNull(voterInfo.otherElections);
+    }
+}

--- a/app/src/main/java/com/votinginfoproject/VotingInformationProject/models/Election.java
+++ b/app/src/main/java/com/votinginfoproject/VotingInformationProject/models/Election.java
@@ -18,6 +18,13 @@ public class Election {
     private SimpleDateFormat election_date_display_format = new SimpleDateFormat("MMMM d, yyyy");
 
     public Election() {
+        this(null, null, null);
+    }
+
+    public Election(String id, String name, String electionDay) {
+        this.id = id;
+        this.name = name;
+        this.electionDay = electionDay;
         election_date_api_format = new SimpleDateFormat("yyyy-MM-dd");
         election_date_display_format = new SimpleDateFormat("MMMM d, yyyy");
     }
@@ -33,5 +40,28 @@ public class Election {
             Log.e("ElectionModel", "Failed to parse election date " + electionDay);
             return electionDay;
         }
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    /**
+     * Getter for name
+     *
+     * @return name or empty string if name null
+     */
+    public String getName() {
+        return (name != null) ? name : "";
+    }
+
+    /**
+     * Getter for id
+     *
+     * @return id or empty string if null
+     */
+    public String getId() {
+        return (id != null) ? id : "";
     }
 }

--- a/app/src/main/java/com/votinginfoproject/VotingInformationProject/models/VoterInfo.java
+++ b/app/src/main/java/com/votinginfoproject/VotingInformationProject/models/VoterInfo.java
@@ -1,5 +1,6 @@
 package com.votinginfoproject.VotingInformationProject.models;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -16,4 +17,13 @@ public class VoterInfo {
     public List<PollingLocation> earlyVoteSites;
     public List<Contest> contests;
     public List<State> state;
+
+    /**
+     * Default Constructor
+     *
+     * Ensures otherElections is never a null field
+     */
+    public VoterInfo() {
+        this.otherElections = new ArrayList<Election>();
+    }
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -78,6 +78,29 @@
         android:textStyle="italic"
         />
 
+    <RelativeLayout
+        android:id="@+id/home_election_spinner_wrapper"
+        android:visibility="gone"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/home_go_button"
+        android:paddingBottom="10dip"
+        android:gravity="center">
+
+        <TextView
+            android:id="@+id/home_election_spinner_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/home_textview_spinner_text"/>
+
+        <Spinner
+            android:id="@+id/home_election_spinner"
+            android:layout_toRightOf="@+id/home_election_spinner_text"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content" />
+
+    </RelativeLayout>
+
     <Button
         android:text="@string/homeactivity_go_button"
         android:id="@+id/home_go_button"

--- a/app/src/main/res/layout/home_election_spinner_view.xml
+++ b/app/src/main/res/layout/home_election_spinner_view.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="10dip"
+    android:gravity="left|center_vertical"
+    android:textSize="16sp" />
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="home_textview_brandname">Brand Name</string>
     <string name="home_textview_votinginfo">Voting Information</string>
     <string name="home_textview_getting_started">Get started by providing the address at which you are registered to vote.</string>
+    <string name="home_textview_spinner_text">Choose an election:</string>
     <string name="home_status_loading">Loading data…</string>
     <string name="home_error_address_not_found">Looks like we can\'t find your address. Please check that it\'s right and try again.</string>
     <string name="home_error_parsing_address">We couldn\'t read the address you entered.  Please check that it\'s right and try again</string>


### PR DESCRIPTION
The behaviour is as such:

If there are other elections in the response,
display the election picker and make another
voterInfo query with the same address when the user selects
another election.

Removes the election picker from view when a voterinfo query
is received that has no other elections in its response.

Added a few tests for VoterInfo/Elections models
