### PR TITLE
Show placeholder text for missing hours of operation.

### DIFF
--- a/app/src/main/java/com/votinginfoproject/VotingInformationProject/fragments/VIPMapFragment.java
+++ b/app/src/main/java/com/votinginfoproject/VotingInformationProject/fragments/VIPMapFragment.java
@@ -292,13 +292,23 @@ public class VIPMapFragment extends SupportMapFragment {
             showTitle = location.address.locationName;
         }
 
-        String showSnippet = location.address.toGeocodeString();
-        showSnippet += "\n\nHours:\n" + location.pollingHours;
+        StringBuilder showSnippet = new StringBuilder(location.address.toGeocodeString());
+
+        if (location.pollingHours != null && !location.pollingHours.isEmpty()) {
+            showSnippet.append("\n\n");
+            showSnippet.append(mResources.getString(R.string.locations_map_polling_location_hours_label));
+            showSnippet.append("\n");
+            showSnippet.append(location.pollingHours);
+        } else {
+            // display placeholder for no hours
+            showSnippet.append("\n\n");
+            showSnippet.append(mResources.getString(R.string.locations_map_polling_location_hours_not_found));
+        }
 
         return new MarkerOptions()
                 .position(new LatLng(location.address.latitude, location.address.longitude))
                 .title(showTitle)
-                .snippet(showSnippet)
+                .snippet(showSnippet.toString())
                 .icon(BitmapDescriptorFactory.defaultMarker(color))
         ;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,8 @@
 	<!-- Locations map strings -->
     <string name="locations_map_user_address_label">User Address</string>
     <string name="locations_map_play_services_unavailable">Google Play services are unavailable.  Cannot show map.</string>
+    <string name="locations_map_polling_location_hours_label">Hours:</string>
+    <string name="locations_map_polling_location_hours_not_found">Hours of operation not found for this location.</string>
 
     <!-- Directions list strings -->
     <string name="directions_walk_button_label">Walk</string>


### PR DESCRIPTION
As requested in meeting, display placeholder text if hours of operation not found for a polling location.
