### PR TITLE
Clear back stack on tab change.

### DIFF
--- a/app/src/main/java/com/votinginfoproject/VotingInformationProject/activities/VIPTabBarActivity.java
+++ b/app/src/main/java/com/votinginfoproject/VotingInformationProject/activities/VIPTabBarActivity.java
@@ -728,6 +728,7 @@ public class VIPTabBarActivity extends FragmentActivity implements GooglePlaySer
         private final ViewPager mViewPager;
         private final ArrayList<TabInfo> mTabs = new ArrayList<TabInfo>(3);
         private LocationsFragment locationsFragment;
+        private FragmentManager tabsFragmentManager;
 
         static final class TabInfo {
             private final Class<?> clss;
@@ -804,7 +805,9 @@ public class VIPTabBarActivity extends FragmentActivity implements GooglePlaySer
 
         @Override
         public void onTabUnselected(ActionBar.Tab tab, android.app.FragmentTransaction ft) {
-
+            // Clear back stack on tab change.  Otherwise stack will keep history for all tabs,
+            // which can result in inconsistent state and/or unexpected behavior.
+            tabsFragmentManager.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
         }
 
         /**


### PR DESCRIPTION
Otherwise back stack retains history for all tabs together, which can result
in inconsistent state and unexpected behavior.  See [discussion here](http://stackoverflow.com/questions/6987334/separate-back-stack-for-each-tab-in-android-using-fragments).
