### PR TITLE
Scroll referendum descriptions.

### DIFF
--- a/app/src/main/java/com/votinginfoproject/VotingInformationProject/fragments/ContestFragment.java
+++ b/app/src/main/java/com/votinginfoproject/VotingInformationProject/fragments/ContestFragment.java
@@ -82,7 +82,18 @@ public class ContestFragment extends Fragment {
                 title.setText(contest.office);
                 subtitle.setText(voterInfo.election.name);
             } else if (contest.type != null) {
+                // Have a referendum, which has no candidates list.  So,
+                // remove scrolling list view and instead use scroll view for title/subtitle.
+                ViewGroup parent = (ViewGroup) myActivity.findViewById(R.id.contest_fragment);
+                parent.removeView(myActivity.findViewById(R.id.contest_fragment_inner_layout));
+                View scroll = myActivity.getLayoutInflater().inflate(R.layout.contest_referendum, parent, false);
+                parent.addView(scroll);
 
+                // go find references to the TextViews in the new ScrollView
+                title = (TextView)myActivity.findViewById(R.id.contest_title);
+                subtitle = (TextView)myActivity.findViewById(R.id.contest_subtitle);
+
+                // deal with huge referendum descriptions by reducing font size a bit.
                 if (contest.referendumTitle != null) {
                     title.setText(contest.referendumTitle);
                     if (contest.referendumTitle.length() > 20) {
@@ -90,9 +101,6 @@ public class ContestFragment extends Fragment {
                     }
                 }
 
-                // deal with huge referendum descriptions by reducing font size.
-                // Cannot make fragment a ScrollView, because it already contains a
-                // scrolling list of candidates.
                 if (contest.referendumSubtitle != null && !contest.referendumSubtitle.isEmpty()) {
                     subtitle.setText(contest.referendumSubtitle);
                     if (contest.referendumSubtitle.length() > 20) {
@@ -115,7 +123,7 @@ public class ContestFragment extends Fragment {
                         myActivity.showCandidateDetails(contestNum, position);
                     }
                 });
-            } else {
+            } else if (!contest.type.equals("Referendum")) {
                 Log.d("ContestFragment", "No candidates found for selected contest.");
                 myActivity.findViewById(R.id.contest_candidate_list_header).setVisibility(View.GONE);
             }

--- a/app/src/main/res/layout/contest_referendum.xml
+++ b/app/src/main/res/layout/contest_referendum.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/contest_referendum_scrollview"
+    style="@style/match_width_match_height">
+
+    <LinearLayout
+        style="@style/wrap_width_wrap_height"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/contest_title"
+            style="@style/fragment_header" />
+
+        <TextView
+            android:id="@+id/contest_subtitle"
+            android:layout_below="@+id/contest_title"
+            style="@style/fragment_subheader" />
+    </LinearLayout>
+
+</ScrollView>


### PR DESCRIPTION
In contest detail view, dynamically switch between scrolling canditates list and scroll view
for title/subtitle based on whether contest is a referendum are not.

Doing this because only one thing that scrolls can be in a view, but referendums have no candidates.
