### PR TITLE
fix - prevent both listeners from being called on error

### DIFF
--- a/app/src/main/java/com/votinginfoproject/VotingInformationProject/asynctasks/CivicInfoApiQuery.java
+++ b/app/src/main/java/com/votinginfoproject/VotingInformationProject/asynctasks/CivicInfoApiQuery.java
@@ -1,7 +1,5 @@
 package com.votinginfoproject.VotingInformationProject.asynctasks;
 
-import android.app.Activity;
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.util.Log;
@@ -9,7 +7,6 @@ import android.util.Log;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
-import com.votinginfoproject.VotingInformationProject.R;
 import com.votinginfoproject.VotingInformationProject.models.CivicApiError;
 
 import org.apache.http.HttpResponse;
@@ -169,6 +166,7 @@ public class CivicInfoApiQuery<T> extends AsyncTask<String, CivicApiError, T> {
 
         clearLastElection();
         errorCallbackListener.callback(errors[0]);
+        cancel(true);
     }
 
     /**


### PR DESCRIPTION
When the response was an error, both callbacks were being called causing the error message in the status textview to be wrong.

A lot more can probably be done here but this works.
